### PR TITLE
Fix `&`.

### DIFF
--- a/simplefunge.rb
+++ b/simplefunge.rb
@@ -72,7 +72,7 @@ while not done
 		when ?!
 			genericOneArg { |n1| $stack.unshift n1; $stack.unshift n1; } #genericOneArg is destructive
 		when ?&
-			genericTwoArg { |n1, n2| $stack[0] = n2, $stack[1] = n1 }
+			genericTwoArg { |n1, n2| $stack.unshift(n2, n1) }
 		when ?| #can't figure out how to do this one generically
 			i = $stack.shift
 			if i >= $stack.length


### PR DESCRIPTION
As implemented, `&` transformed the stack `[3, 117, 108, 100, 33]` (e.g.) into `[[117, 3], 3, 33]`. In case it matters, this is with Ruby 2.4.1. The revised code transforms it into `[117, 3, 108, 100, 33]`, as expected.